### PR TITLE
Update CI to use new location of dev-requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             make install-deps
             python3 -m venv .venv
             source .venv/bin/activate
-            pip install --require-hashes -r dev-requirements.txt
+            pip install --require-hashes -r requirements/dev-requirements.txt
             sudo apt-get install -y file
             make black
   buildrpm:


### PR DESCRIPTION
# Description

CI is currently failing due a reference to an old location of `dev-requirements.txt`. This PR updates the location in the CI config.

# Testing

- [ ] CI for this PR is green