### PR TITLE
Harden reproducibility

### DIFF
--- a/rpm-build/SPECS/securedrop-updater.spec
+++ b/rpm-build/SPECS/securedrop-updater.spec
@@ -64,7 +64,13 @@ install -m 755 files/sdw-login %{buildroot}/%{_bindir}/
 install -m 644 README.md %{buildroot}/%{_custom_docdir}/
 install -m 644 LICENSE %{buildroot}/%{_custom_licensedir}/
 find %{buildroot} -type d \( -iname '*.egg-info' -o -iname '*.dist-info' \) -print0 | xargs -0 -r rm -rf
+# Usually, the __spec_install_post macro is automatically expanded at the end of
+# the install scriplet, but it can also affect the mtime of files/folders
+%{__spec_install_post}
+# Enforce mtimes for reproducibility
 find %{buildroot} -exec touch -m -d @%{getenv:SOURCE_DATE_EPOCH} {} +
+# Don't run __spec_install_post again
+%global __spec_install_post %{nil}
 
 
 %files


### PR DESCRIPTION
`%install` scriptlets will have certain macros expand automatically - one of that is `%__spec_install_post` which will run `/usr/lib/rpm/redhat/brp-mangle-shebangs`. This script can affect modification dates for the folders containing scripts which have gotten their shebang mangled, which in certain circumstances breaks reproducibility along with it.

So we work around that by running the whole macro manually before we enforce modification times for reproducibility, after which we redefine the macro so it doesn't run unnecessarily.

# Testing

- [ ] CI is happy (green)
- [ ] `make reprotest` is happy