### PR TITLE
Fix `make isort`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ check-isort: ## Check Python import organization with isort
 
 .PHONY: isort
 isort: ## Update Python import organization with isort
-	isort --diff .
+	isort .
 
 .PHONY: flake8
 flake8: ## Validate PEP8 compliance for Python source files


### PR DESCRIPTION
The `--diff` argument means it prints the diff instead of changing the files. Now it will actually modify any files that need sorting.