### PR TITLE
Test improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ bandit: ## Runs the bandit security linter
 
 .PHONY: test
 test: ## Runs tests with the X Virtual framebuffer
-	$(CONTAINER) xvfb-run python3 -m pytest --cov-report term-missing --cov=sdw_notify --cov=sdw_updater --cov=sdw_util -v tests/
+	$(CONTAINER) xvfb-run python3 -m pytest -v
 
 .PHONY: check-black
 check-black: ## Check Python source code formatting with black

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ bandit: ## Runs the bandit security linter
 	bandit -ll --exclude ./.venv/ -r .
 
 .PHONY: test
-test: ## Runs tests with the X Virtual framebuffer
-	$(CONTAINER) xvfb-run python3 -m pytest -v
+test: ## Runs tests
+	$(CONTAINER) python3 -m pytest -v
 
 .PHONY: check-black
 check-black: ## Check Python source code formatting with black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ extend-exclude = ".venv"
 [tool.isort]
 line_length = 100
 profile = "black"
+
+[tool.pytest.ini_options]
+addopts = "--cov-report term-missing --cov=sdw_notify --cov=sdw_updater --cov=sdw_util"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def tmpdir():
+    """Run the test in a temporary directory"""
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory(prefix="updater") as tmpdir:
+        os.chdir(tmpdir)
+        yield tmpdir
+        os.chdir(cwd)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -165,12 +165,9 @@ def test_write_updates_status_flag_to_disk(
     )
 
     assert os.path.exists(flag_file_dom0)
-    try:
-        with open(flag_file_dom0, "r") as f:
-            contents = json.load(f)
-            assert contents["status"] == status.value
-    except Exception:
-        pytest.fail("Error reading file")
+    with open(flag_file_dom0, "r") as f:
+        contents = json.load(f)
+        assert contents["status"] == status.value
     assert "tmp" in flag_file_dom0
     assert not mocked_error.called
 
@@ -225,11 +222,8 @@ def test_write_last_updated_flags_to_disk(mocked_info, mocked_error, mocked_call
     mocked_call.assert_called_once_with(subprocess_command)
     assert not mocked_error.called
     assert os.path.exists(flag_file_dom0)
-    try:
-        contents = open(flag_file_dom0, "r").read()
-        assert contents == current_time
-    except Exception:
-        pytest.fail("Error reading file")
+    contents = open(flag_file_dom0, "r").read()
+    assert contents == current_time
 
 
 @mock.patch("os.path.expanduser", return_value=temp_dir)
@@ -572,12 +566,9 @@ def test_read_dom0_update_flag_from_disk(
     flag_file_dom0 = updater.get_dom0_path(updater.FLAG_FILE_STATUS_DOM0)
 
     assert os.path.exists(flag_file_dom0)
-    try:
-        with open(flag_file_dom0, "r") as f:
-            contents = json.load(f)
-            assert contents["status"] == status.value
-    except Exception:
-        pytest.fail("Error reading file")
+    with open(flag_file_dom0, "r") as f:
+        contents = json.load(f)
+        assert contents["status"] == status.value
     assert "tmp" in flag_file_dom0
 
     assert updater.read_dom0_update_flag_from_disk() == status
@@ -596,11 +587,8 @@ def test_read_dom0_update_flag_from_disk_fails(
 ):
 
     flag_file_dom0 = updater.get_dom0_path(updater.FLAG_FILE_STATUS_DOM0)
-    try:
-        with open(flag_file_dom0, "w") as f:
-            f.write("something")
-    except Exception:
-        pytest.fail("Error writing file")
+    with open(flag_file_dom0, "w") as f:
+        f.write("something")
 
     info_calls = [call("Cannot read dom0 status flag, assuming first run")]
 

--- a/tests/test_updaterapp.py
+++ b/tests/test_updaterapp.py
@@ -1,8 +1,10 @@
 import os
+import subprocess
 import unittest
 from importlib.machinery import SourceFileLoader
-from unittest import TestCase, mock
+from unittest import mock
 
+import pytest
 from PyQt5.QtWidgets import QApplication
 
 relpath_updaterapp_script = "../sdw_updater/UpdaterApp.py"
@@ -14,116 +16,121 @@ path_to_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), relpat
 strings = SourceFileLoader("strings", path_to_script).load_module()
 
 
-class TestUpdaterApp(TestCase):
-    _app = None
+@pytest.fixture(scope="module", autouse=True)
+def app():
+    with subprocess.Popen(["/usr/bin/Xvfb", ":99"]) as xvfb:
+        os.environ["DISPLAY"] = ":99"
+        app = QApplication([])
+        yield app
+        app.quit()
+        xvfb.kill()
 
-    @classmethod
-    def setUpClass(cls):
-        cls._app = QApplication([])  # noqa: F841
 
-    @classmethod
-    def tearDownClass(cls):
-        cls._app.quit()
+@mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
+@mock.patch("UpdaterApp.subprocess.check_output", return_value=b"none")
+def test_netcheck_no_network_should_fail(mocked_output, mocked_qubes_version):
+    """
+    When the host machine has no network connectivity
+    Then the error is logged
+     And netcheck returns False
+    """
+    assert not updater_app._is_netcheck_successful()
 
-    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
-    @mock.patch("UpdaterApp.subprocess.check_output", return_value=b"none")
-    def test_netcheck_no_network_should_fail(self, mocked_output, mocked_qubes_version):
-        """
-        When the host machine has no network connectivity
-        Then the error is logged
-         And netcheck returns False
-        """
-        assert not updater_app._is_netcheck_successful()
 
-    @mock.patch("Util.get_qubes_version", return_value=None)
-    @mock.patch("UpdaterApp.logger.error")
-    def test_netcheck_no_qubes_should_fail_with_error(self, mocked_error, mocked_qubes_version):
-        """
-        When the network connectivity check is run outside of Qubes
-        Then the check should return not succeed
-         And an error should be logged
-        """
-        assert not updater_app._is_netcheck_successful()
-        assert mocked_error.called
+@mock.patch("Util.get_qubes_version", return_value=None)
+@mock.patch("UpdaterApp.logger.error")
+def test_netcheck_no_qubes_should_fail_with_error(mocked_error, mocked_qubes_version):
+    """
+    When the network connectivity check is run outside of Qubes
+    Then the check should return not succeed
+     And an error should be logged
+    """
+    assert not updater_app._is_netcheck_successful()
+    assert mocked_error.called
 
-    @mock.patch("subprocess.check_output", return_value=b"full")
-    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
-    def test_netcheck_should_succeed(self, mocked_qubes_version, mocked_output):
-        """
-        When the network connectivity check is run in Qubes
-         And nmcli detects a connection
-        Then the network check should succeed
-        """
-        assert updater_app._is_netcheck_successful()
 
-    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
-    @mock.patch("UpdaterApp.logger.error")
-    @mock.patch("subprocess.check_output", return_value=b"none")
-    def test_updater_app_with_no_connectivity_should_error(
-        self, mocked_output, mocked_error, mocked_qubes_version
-    ):
-        """
-        When the netcheck method is run
-         And the network check is unsuccessful
-        Then the network error view should be visible
-        """
-        updater_app_dialog = updater_app.UpdaterApp()
-        updater_app_dialog._check_network_and_update()
-        assert self._is_network_fail_view(updater_app_dialog)
+@mock.patch("subprocess.check_output", return_value=b"full")
+@mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
+def test_netcheck_should_succeed(mocked_qubes_version, mocked_output):
+    """
+    When the network connectivity check is run in Qubes
+     And nmcli detects a connection
+    Then the network check should succeed
+    """
+    assert updater_app._is_netcheck_successful()
 
-    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
-    @mock.patch("subprocess.check_output", return_value=b"full")
-    @mock.patch("UpdaterApp.logger.info")
-    @mock.patch("UpdaterApp.UpgradeThread")
-    def test_updater_app_with_connectivity_should_succeed(
-        self, mocked_thread, mocked_logger, mocked_output, mocked_qubes_version
-    ):
-        """
-        When the netcheck is run
-         And the network check is successful
-        Then the Preflight Updater should begin to check for updates
-         And the progress view should be visible
-        """
-        updater_app_dialog = updater_app.UpdaterApp()
-        updater_app_dialog._check_network_and_update()
-        assert self._is_progress_view(updater_app_dialog)
 
-    @mock.patch("UpdaterApp.UpgradeThread")
-    def test_updater_app_with_override(self, mocked_thread):
-        """
-        When the netcheck is overridden (skipped)
-         And there is no network connectivity
-        Then `apply updates` should still be called
-         And the progress bar should be visible
-        """
-        updater_app_dialog = updater_app.UpdaterApp(should_skip_netcheck=True)
-        updater_app_dialog._check_network_and_update()
-        assert self._is_progress_view(updater_app_dialog)
+@mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
+@mock.patch("UpdaterApp.logger.error")
+@mock.patch("subprocess.check_output", return_value=b"none")
+def test_updater_app_with_no_connectivity_should_error(
+    mocked_output, mocked_error, mocked_qubes_version
+):
+    """
+    When the netcheck method is run
+     And the network check is unsuccessful
+    Then the network error view should be visible
+    """
+    updater_app_dialog = updater_app.UpdaterApp()
+    updater_app_dialog._check_network_and_update()
+    assert is_network_fail_view(updater_app_dialog)
 
-    def _is_progress_view(self, dialog: updater_app.UpdaterApp) -> bool:
-        """
-        Helper method to test assumptions about Dialog UI state.
-        """
-        return (
-            dialog.progressBar.isVisible()
-            and not dialog.applyUpdatesButton.isVisible()
-            and dialog.cancelButton.isVisible()
-            and not dialog.cancelButton.isEnabled()
-            and dialog.proposedActionDescription.text()
-            == strings.description_status_applying_updates
-        )
 
-    def _is_network_fail_view(self, dialog: updater_app.UpdaterApp) -> bool:
-        """
-        Helper method to test assumptions about Dialog UI state.
-        """
-        return (
-            not dialog.progressBar.isVisible()
-            and not dialog.applyUpdatesButton.isVisible()
-            and dialog.cancelButton.isVisible()
-            and dialog.cancelButton.isEnabled()
-            and dialog.proposedActionDescription.text() == strings.description_error_network
-        )
+@mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.1")
+@mock.patch("subprocess.check_output", return_value=b"full")
+@mock.patch("UpdaterApp.logger.info")
+@mock.patch("UpdaterApp.UpgradeThread")
+def test_updater_app_with_connectivity_should_succeed(
+    mocked_thread, mocked_logger, mocked_output, mocked_qubes_version
+):
+    """
+    When the netcheck is run
+     And the network check is successful
+    Then the Preflight Updater should begin to check for updates
+     And the progress view should be visible
+    """
+    updater_app_dialog = updater_app.UpdaterApp()
+    updater_app_dialog._check_network_and_update()
+    assert is_progress_view(updater_app_dialog)
+
+
+@mock.patch("UpdaterApp.UpgradeThread")
+def test_updater_app_with_override(mocked_thread):
+    """
+    When the netcheck is overridden (skipped)
+     And there is no network connectivity
+    Then `apply updates` should still be called
+     And the progress bar should be visible
+    """
+    updater_app_dialog = updater_app.UpdaterApp(should_skip_netcheck=True)
+    updater_app_dialog._check_network_and_update()
+    assert is_progress_view(updater_app_dialog)
+
+
+def is_progress_view(dialog: updater_app.UpdaterApp) -> bool:
+    """
+    Helper method to test assumptions about Dialog UI state.
+    """
+    return (
+        dialog.progressBar.isVisible()
+        and not dialog.applyUpdatesButton.isVisible()
+        and dialog.cancelButton.isVisible()
+        and not dialog.cancelButton.isEnabled()
+        and dialog.proposedActionDescription.text() == strings.description_status_applying_updates
+    )
+
+
+def is_network_fail_view(dialog: updater_app.UpdaterApp) -> bool:
+    """
+    Helper method to test assumptions about Dialog UI state.
+    """
+    return (
+        not dialog.progressBar.isVisible()
+        and not dialog.applyUpdatesButton.isVisible()
+        and dialog.cancelButton.isVisible()
+        and dialog.cancelButton.isEnabled()
+        and dialog.proposedActionDescription.text() == strings.description_error_network
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,6 @@ import os
 import re
 import subprocess
 from importlib.machinery import SourceFileLoader
-from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -28,11 +27,11 @@ DEBIAN_VERSION = "bullseye"
 @mock.patch("Util.sdlog.error")
 @mock.patch("Util.sdlog.warning")
 @mock.patch("Util.sdlog.info")
-def test_obtain_lock(mocked_info, mocked_warning, mocked_error):
+def test_obtain_lock(mocked_info, mocked_warning, mocked_error, tmpdir):
     """
     Test whether we can successfully obtain an exclusive lock
     """
-    with TemporaryDirectory() as tmpdir, mock.patch("Util.LOCK_DIRECTORY", tmpdir):
+    with mock.patch("Util.LOCK_DIRECTORY", tmpdir):
 
         basename = "test-obtain-lock.lock"
         pid_str = str(os.getpid())
@@ -59,7 +58,7 @@ def test_obtain_lock(mocked_info, mocked_warning, mocked_error):
 @mock.patch("Util.sdlog.error")
 @mock.patch("Util.sdlog.warning")
 @mock.patch("Util.sdlog.info")
-def test_cannot_obtain_exclusive_lock_when_busy(mocked_info, mocked_warning, mocked_error):
+def test_cannot_obtain_exclusive_lock_when_busy(mocked_info, mocked_warning, mocked_error, tmpdir):
     """
     Test whether only a single process can obtan an exclusive lock (basic
     lockfile behavior).
@@ -67,7 +66,7 @@ def test_cannot_obtain_exclusive_lock_when_busy(mocked_info, mocked_warning, moc
     This is used to prevent multiple preflight updaters or multiple notifiers
     from being instantiated.
     """
-    with TemporaryDirectory() as tmpdir, mock.patch("Util.LOCK_DIRECTORY", tmpdir):
+    with mock.patch("Util.LOCK_DIRECTORY", tmpdir):
 
         basename = "test-exclusive-lock.lock"
         lh1 = util.obtain_lock(basename)  # noqa: F841
@@ -85,7 +84,7 @@ def test_cannot_obtain_exclusive_lock_when_busy(mocked_info, mocked_warning, moc
 @mock.patch("Util.sdlog.error")
 @mock.patch("Util.sdlog.warning")
 @mock.patch("Util.sdlog.info")
-def test_cannot_obtain_shared_lock_when_busy(mocked_info, mocked_warning, mocked_error):
+def test_cannot_obtain_shared_lock_when_busy(mocked_info, mocked_warning, mocked_error, tmpdir):
     """
     Test whether an exlusive lock on a lock file is successfully detected
     by means of attempting to obtain a shared, nonexclusive lock on the same
@@ -94,7 +93,7 @@ def test_cannot_obtain_shared_lock_when_busy(mocked_info, mocked_warning, mocked
     In the preflight updater / notifier, this is used to prevent the notification
     from being displayed when the preflight updater is already open.
     """
-    with TemporaryDirectory() as tmpdir, mock.patch("Util.LOCK_DIRECTORY", tmpdir):
+    with mock.patch("Util.LOCK_DIRECTORY", tmpdir):
 
         basename = "test-conflict.lock"
         lh = util.obtain_lock(basename)  # noqa: F841
@@ -112,13 +111,13 @@ def test_cannot_obtain_shared_lock_when_busy(mocked_info, mocked_warning, mocked
 @mock.patch("Util.sdlog.error")
 @mock.patch("Util.sdlog.warning")
 @mock.patch("Util.sdlog.info")
-def test_no_lockfile_no_problems(mocked_info, mocked_warning, mocked_error):
+def test_no_lockfile_no_problems(mocked_info, mocked_warning, mocked_error, tmpdir):
     """
     Test whether our shared lock test succeeds even when there's no lockfile
     (which means the process has not run recently, or ever, and it's safe to
     run the potentially conflicting process).
     """
-    with TemporaryDirectory() as tmpdir, mock.patch("Util.LOCK_DIRECTORY", tmpdir):
+    with mock.patch("Util.LOCK_DIRECTORY", tmpdir):
         lock_result = util.can_obtain_lock("404.lock")
         assert lock_result is True
 
@@ -142,12 +141,12 @@ def test_permission_error_is_handled(mocked_info, mocked_warning, mocked_error):
 @mock.patch("Util.sdlog.error")
 @mock.patch("Util.sdlog.warning")
 @mock.patch("Util.sdlog.info")
-def test_stale_lockfile_has_no_effect(mocked_info, mocked_warning, mocked_error):
+def test_stale_lockfile_has_no_effect(mocked_info, mocked_warning, mocked_error, tmpdir):
     """
     Test whether we can get a shared lock when a lockfile exists, but nobody
     is accessing it.
     """
-    with TemporaryDirectory() as tmpdir, mock.patch("Util.LOCK_DIRECTORY", tmpdir):
+    with mock.patch("Util.LOCK_DIRECTORY", tmpdir):
 
         # Because we're not assigning the return value, it will be immediately released
         basename = "test-stale.lock"
@@ -156,11 +155,11 @@ def test_stale_lockfile_has_no_effect(mocked_info, mocked_warning, mocked_error)
         assert lock_result is True
 
 
-def test_log():
+def test_log(tmpdir):
     """
     Test whether we can successfully write to a log file
     """
-    with TemporaryDirectory() as tmpdir, mock.patch("Util.LOG_DIRECTORY", tmpdir):
+    with mock.patch("Util.LOG_DIRECTORY", tmpdir):
         basename = "test.log"
         # configure_logging is expected to re-create the directory.
         os.rmdir(tmpdir)


### PR DESCRIPTION
* Move pytest configuration into pyproject.toml
* Add test fixture for running in a temporary directory
* Don't catch exceptions and then fail in tests
* Have test_updaterapp use standard functional pytest structure

The main motivation for this PR is commit #2, setting up the `tmpdir` fixture, but I saw other things and kept cleaning things up...

## Test plan
* [x] CI passes
* [x] `make check` passes locally