### PR TITLE
Small reproducibility improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-rpm: ## Build RPM package
 
 .PHONY: reprotest
 reprotest: ## Check RPM package reproducibility
-	TERM=xterm-256color $(CONTAINER) bash -c "sudo ln -s $$PWD/scripts/fake-setarch.py /usr/local/bin/setarch && sudo reprotest 'make build-rpm' 'rpm-build/RPMS/noarch/*.rpm' --variations '+all,-fileordering,-domain_host,-kernel'"
+	TERM=xterm-256color $(CONTAINER) bash -c "sudo ln -s $$PWD/scripts/fake-setarch.py /usr/local/bin/setarch && sudo reprotest 'make build-rpm' 'rpm-build/RPMS/noarch/*.rpm' --variations '+all,+kernel,-domain_host,-fileordering'"
 
 # Installs Fedora 32 package dependencies, to build RPMs and run tests,
 # primarily useful in CI/containers

--- a/rpm-build/SPECS/securedrop-updater.spec
+++ b/rpm-build/SPECS/securedrop-updater.spec
@@ -15,14 +15,9 @@ Summary:	SecureDrop Updater
 #     For easy reproducibility we'll keep everything
 %define _changelog_trimtime 0
 %define _changelog_trimage 0
-#   * _buildhost varies based on environment, we build via Docker but ensure
+#   * _buildhost varies based on environment, we build via containers but ensure
 #     this is the same regardless
 %global _buildhost %{name}
-#   * _custom_docdir and _custom_licensedir are workarounds for their respecitve
-#      macros not supporting SOURCE_DATE_EPOCH
-%global _custom_docdir %{_datadir}/doc/%{name}
-%global _custom_licensedir %{_datadir}/licenses/%{name}
-#   * compiling Python bytecode is not reproducible at the time of writing
 %undefine py_auto_byte_compile
 
 License:	AGPLv3
@@ -60,17 +55,12 @@ install -m 755 -d %{buildroot}/%{_datadir}/applications/
 install -m 755 -d %{buildroot}/%{_datadir}/icons/hicolor/128x128/apps/
 install -m 755 -d %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/
 install -m 755 -d %{buildroot}/%{_sharedstatedir}/%{name}/
-# Create doc dir manually, because doc macro doesn't honor SOURCE_DATE_EPOCH.
-install -m 755 -d %{buildroot}/%{_custom_docdir}
-install -m 755 -d %{buildroot}/%{_custom_licensedir}
 install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}/%{_datadir}/applications/
 install -m 644 files/securedrop-128x128.png %{buildroot}/%{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 install -m 644 files/securedrop-scalable.svg %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
 install -m 755 files/sdw-updater %{buildroot}/%{_bindir}/
 install -m 755 files/sdw-notify %{buildroot}/%{_bindir}/
 install -m 755 files/sdw-login %{buildroot}/%{_bindir}/
-install -m 644 README.md %{buildroot}/%{_custom_docdir}/
-install -m 644 LICENSE %{buildroot}/%{_custom_licensedir}/
 
 
 %files
@@ -85,8 +75,8 @@ install -m 644 LICENSE %{buildroot}/%{_custom_licensedir}/
 %{python3_sitelib}/*%{version}.dist-info/*
 %{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 %{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
-%{_custom_docdir}/README.md
-%{_custom_licensedir}/LICENSE
+%doc README.md
+%license LICENSE
 
 
 %changelog


### PR DESCRIPTION
# Description

* mtime clamping takes care of issues with `%doc` and `%license` macros, no need for custom trickery
* Turns out we can use the same reprotest variations as securedrop-workstation!

# Testing

- [ ] CI is :green_apple: 