### PR TITLE
Add systemd timers for `sdw-notify`

### DIFF
--- a/files/sdw-notify.service
+++ b/files/sdw-notify.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=SecureDrop Updater GUI Notification
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/sdw-notify

--- a/files/sdw-notify.timer
+++ b/files/sdw-notify.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=SecureDrop Updater GUI Notification
+
+[Timer]
+OnStartupSec=2h
+OnUnitActiveSec=2h
+
+[Install]
+WantedBy=default.target

--- a/rpm-build/SPECS/securedrop-updater.spec
+++ b/rpm-build/SPECS/securedrop-updater.spec
@@ -30,6 +30,7 @@ BuildRequires:	python3-devel
 BuildRequires:	python3-pip
 BuildRequires:	python3-setuptools
 BuildRequires:	python3-wheel
+BuildRequires:	systemd-rpm-macros
 
 # SecureDrop Updater triggers Salt to update templates and has a Qt5 based UI
 Requires:		qubes-mgmt-salt-dom0-virtual-machines
@@ -56,6 +57,7 @@ install -m 755 -d %{buildroot}/%{_datadir}/icons/hicolor/128x128/apps/
 install -m 755 -d %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/
 install -m 755 -d %{buildroot}/%{_libexecdir}/%{name}/migrations/
 install -m 755 -d %{buildroot}/%{_sharedstatedir}/%{name}/
+install -m 755 -d %{buildroot}/%{_userunitdir}/
 install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}/%{_datadir}/applications/
 install -m 644 files/securedrop-128x128.png %{buildroot}/%{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 install -m 644 files/securedrop-scalable.svg %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
@@ -66,6 +68,8 @@ install -m 755 files/migrations.py %{buildroot}/%{_libexecdir}/%{name}/
 install -m 644 files/migration_steps.py %{buildroot}/%{_libexecdir}/%{name}/
 # Uncomment and replace $ with % when migrations are added:
 # install -m 644 migrations/*.py ${buildroot}/${_libexecdir}/${name}/migrations/
+install -m 644 files/sdw-notify.service %{buildroot}/%{_userunitdir}/
+install -m 644 files/sdw-notify.timer %{buildroot}/%{_userunitdir}/
 
 
 %files
@@ -85,6 +89,8 @@ install -m 644 files/migration_steps.py %{buildroot}/%{_libexecdir}/%{name}/
 %{python3_sitelib}/*%{version}.dist-info/*
 %{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 %{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
+%{_userunitdir}/sdw-notify.service
+%{_userunitdir}/sdw-notify.timer
 %doc README.md
 %license LICENSE
 %dir %{_sharedstatedir}/%{name}/


### PR DESCRIPTION
## Description

`sdw-notify` is intended to remind users to run the SecureDrop Updater - it runs once every 2 hours. So far we've been doing that by adding a line to `/etc/crontab` - instead, this allows us to run it with systemd, a user session which is automatically started when logging into `dom0`.

The package by itself does _not_ configure the systemd units it supplies on regular installations, as this is expected to be handled upstream by `securedrop-workstation`. For upgrades though, it will be handled with the migration in #28 

Fixes #21

## Reviewing and testing

There's 2 parts to this change, no. 1 is the systemd units themselves, no. 2 is the packaging.

1. To confirm `systemd` units work as intended, it's easier to review a dummy than the actual services we install here.
   - Copy `sdw-notify.timer` and `sdw-notify.service` to `~/.config/systemd/user/` in `dom0`. _Installing the full RPM package is not necessary._
   - In `sdw-notify.service` replace `/usr/bin/sdw-notify` with `/usr/bin/xfce4-about`
   - To speed up the process testing process, in `sdw-notify.timer` replace both instances of `2h` with `3m`
   - Run
     ```
     systemctl --user daemon-reload
     systemctl --user enable sdw-notify.timer
     ```
     and reboot. 
   - [x] Right after logging back into your session, open `dom0` terminal and run `systemctl --user status sdw-notify.timer` and see that the `Trigger:` field is approximately 3 minutes into the future of when you logged in
   - [x] After 3 minutes of logging in, the XFCE4 About GUI starts.
   - [x] Wait another 3 minutes, and the XFCE3 About GUI starts again.
   - (Cleanup: `systemctl --user disable sdw-notify.timer --now && rm ~/.config/systemd/user/sdw-notify*`)
2. Packaging
   - [ ] Confirm the spec changes comply with [packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Systemd/)
   - [x] `make test-rpm-install` runs successfully
 