### PR TITLE
Reproducibility related `fake-setarch.py`: Fix IndexErrors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+extend-ignore = E203
 max-line-length = 100
 exclude = 
     .venv/

--- a/scripts/fake-setarch.py
+++ b/scripts/fake-setarch.py
@@ -5,5 +5,5 @@
 from subprocess import run
 from sys import argv
 
-start = 3 if argv[2] == "-R" else 2
-run(argv[start:])
+if "sh" in argv:
+    run(argv[argv.index("sh") :])


### PR DESCRIPTION
## Description

Some invocations of setarch seem to be nested (?)/don't do anything, but seeing fewer errors is definitely desirable even if it has no impact on reproducibility

## Testing

- [ ] CI is happy
- [ ] There's no `IndexError` or other `fake-setarch.py` related errors in reprotest output