### PR TITLE
Make migrations log to `systemd-journald`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ reprotest: ## Check RPM package reproducibility
 install-deps:
 	sudo dnf install -y \
         git file python3-devel python3-pip python3-qt5 python3-wheel \
-		xorg-x11-server-Xvfb rpmdevtools rpmlint which libfaketime ShellCheck
+		xorg-x11-server-Xvfb rpmdevtools rpmlint which libfaketime ShellCheck \
+		python3-systemd
 
 .PHONY: update-pip-requirements
 update-pip-requirements: ## Updates all Python requirements files via pip-compile.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Because `securedrop-updater` is used exclusively with Fedora 32 (see above), it 
    - (If you're on Debian/Ubuntu) `apt install python3-venv`
 - Set up the virtual environment:
    - Run `make venv && source .venv/bin/activate` - it will automatically create a virtual environment with `python3.8` if it is available on your machine. Otherwise, it will use your systems default Python interpreter.
-   - If  used your systems default Python interpreter, install PyQt5:
-     - (On Debian/Ubuntu) `apt install python3-pyqt5`
-     - (On Fedora) `dnf install python3-qt5`
+   - If you used your systems default Python interpreter, install PyQt5 and python-systemd:
+     - (On Debian/Ubuntu) `apt install python3-pyqt5 python3-systemd`
+     - (On Fedora) `dnf install python3-qt5 python3-systemd`
    - If you used an alternative Python interpreter to create your virtual environment, install PyQt5 from PyPi:
-     - `pip install PyQt5==5.14.2`
+     - `pip install PyQt5==5.14.2 systemd-python==234`
 
 After installing the development dependencies:
 

--- a/files/migrations.py
+++ b/files/migrations.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import List
 
 from migration_steps import MigrationStep
+from systemd.journal import JournalHandler  # type: ignore
 
 
 class Version:
@@ -185,7 +186,9 @@ def main(version_file: Path, migrations_dir: Path, action: int, version_target: 
 
 if __name__ == "__main__":  # pragma: no cover
     PROJECT = sys.argv[1]
-    logging.basicConfig(filename=f"/var/log/{PROJECT}-migrations.log", level=logging.INFO)
+    log = logging.getLogger()
+    log.addHandler(JournalHandler(SYSLOG_IDENTIFIER=f"{PROJECT}-migrations"))
+    log.setLevel(logging.INFO)
     main(
         Path(f"/var/lib/{PROJECT}/version"),
         Path(f"/usr/libexec/{PROJECT}/migrations/"),

--- a/rpm-build/SPECS/securedrop-updater.spec
+++ b/rpm-build/SPECS/securedrop-updater.spec
@@ -32,9 +32,11 @@ BuildRequires:	python3-setuptools
 BuildRequires:	python3-wheel
 BuildRequires:	systemd-rpm-macros
 
-# SecureDrop Updater triggers Salt to update templates and has a Qt5 based UI
+# SecureDrop Updater triggers Salt to update templates and has a Qt5 based UI,
+# migrations log to systemd-journal
 Requires:		qubes-mgmt-salt-dom0-virtual-machines
 Requires:		python3-qt5
+Requires:		python3-systemd
 
 
 %description


### PR DESCRIPTION
Logging to our own global system file would introduce a couple pitfalls, logging to `systemd-journald` instead allows us to not worry about any of them. Inspecting the log can be done with `journalctl -t securedrop-updater-migrations`. Obsoletes #22 as `journald` housekeeping is done natively by `systemd-journald`.

## Notes

Unfortunately, there's no types/stubs for `systemd-python`, so the `systemd.journal` import has an unfortunate `# type: ignore` attached to it

## Testing

- [x] CI is happy (`caplog` fixture still captures log messages)
- [x] Verifying that logging to journald works is a bit annoying as it can't be done in a normal podman/docker container and configuring `systemd-nspawn` just for this is overkill, so the quickest way to go about verifying that the code does what it should is by installing `python3-systemd` (or `systemd-python` with pip), creating a little `log-test.py`:
  ```
  import logging
  from systemd.journal import JournalHandler

  log = logging.getLogger()
  log.addHandler(JournalHandler(SYSLOG_IDENTIFIER="log-test"))
  log.setLevel(logging.INFO)
  logging.info("Hello World")
  ```
  Followed by running `python3 log-test.py` and `journalctl -t log-test`, which should "Hello World"
