### PR TITLE
Catch up with securedrop-workstation#844

### DIFF
--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -18,7 +18,7 @@ def launch_securedrop_client():
     """
     try:
         logger.info("Launching SecureDrop client")
-        subprocess.Popen(["qvm-run", "sd-app", "gtk-launch securedrop-client"])
+        subprocess.Popen(["qvm-run", "sd-app", "gtk-launch press.freedom.SecureDropClient"])
     except subprocess.CalledProcessError as e:
         logger.error("Error while launching SecureDrop client")
         logger.error(str(e))


### PR DESCRIPTION
freedomofpress/securedrop-workstation#844 introduced a change to the updater, specifically how it opens the SD client. freedomofpress/securedrop-client#1600 introduced a new `.desktop` file that is more in line with freedesktop specs.

## Testing

- [x] CI is cool with the change :+1: